### PR TITLE
Rename method in ScriptManager interface

### DIFF
--- a/octopus/src/main/kotlin/com/koupper/octopus/Config.kt
+++ b/octopus/src/main/kotlin/com/koupper/octopus/Config.kt
@@ -23,7 +23,7 @@ class Config : ScriptManager {
         return this.deployableName
     }
 
-    override fun toDeployableJar(name: String): ScriptManager {
+    override fun toDeployableProjectNamed(name: String): ScriptManager {
         this.deployableName = name
         this.deploymentType = DeploymentType.JAR
 

--- a/octopus/src/main/kotlin/com/koupper/octopus/DeploymentManager.kt
+++ b/octopus/src/main/kotlin/com/koupper/octopus/DeploymentManager.kt
@@ -1,5 +1,5 @@
 package com.koupper.octopus
 
 interface DeploymentManager {
-    fun toDeployableJar(name: String): DeploymentManager
+    fun toDeployableProjectNamed(name: String): DeploymentManager
 }

--- a/octopus/src/main/kotlin/com/koupper/octopus/ScriptManager.kt
+++ b/octopus/src/main/kotlin/com/koupper/octopus/ScriptManager.kt
@@ -9,5 +9,5 @@ interface ScriptManager : DeploymentManager {
 
     fun deployableName() : String
 
-    override fun toDeployableJar(name: String): ScriptManager
+    fun toDeployableProjectNamed(name: String): ScriptManager
 }


### PR DESCRIPTION
After: toDeployableJar now: toDeployableProject